### PR TITLE
Fixed concurrency issues #42

### DIFF
--- a/Source/Core.EntityFramework/Stores/BaseTokenStore.cs
+++ b/Source/Core.EntityFramework/Stores/BaseTokenStore.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System.Data.Entity.Infrastructure;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -39,7 +40,7 @@ namespace Thinktecture.IdentityServer.EntityFramework
             if (context == null) throw new ArgumentNullException("context");
             if (scopeStore == null) throw new ArgumentNullException("scopeStore");
             if (clientStore == null) throw new ArgumentNullException("clientStore");
-            
+
             this.context = context;
             this.tokenType = tokenType;
             this.scopeStore = scopeStore;
@@ -85,27 +86,44 @@ namespace Thinktecture.IdentityServer.EntityFramework
             if (token != null)
             {
                 context.Tokens.Remove(token);
-                await context.SaveChangesAsync();
+
+                try
+                {
+                    await context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException ex)
+                {
+                    var entry = ex.Entries.Single();
+
+                    if (entry.State == EntityState.Deleted)
+                    {
+                        entry.State = EntityState.Detached;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
             }
         }
 
         public async Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject)
         {
-            var tokens = await context.Tokens.Where(x => 
+            var tokens = await context.Tokens.Where(x =>
                 x.SubjectId == subject &&
                 x.TokenType == tokenType).ToArrayAsync();
-            
-            var results = tokens.Select(x=>ConvertFromJson(x.JsonCode)).ToArray();
+
+            var results = tokens.Select(x => ConvertFromJson(x.JsonCode)).ToArray();
             return results.Cast<ITokenMetadata>();
         }
-        
+
         public async Task RevokeAsync(string subject, string client)
         {
-            var found = context.Tokens.Where(x => 
-                x.SubjectId == subject && 
-                x.ClientId == client && 
+            var found = context.Tokens.Where(x =>
+                x.SubjectId == subject &&
+                x.ClientId == client &&
                 x.TokenType == tokenType).ToArray();
-            
+
             context.Tokens.RemoveRange(found);
             await context.SaveChangesAsync();
         }


### PR DESCRIPTION
#42

My mobile app is very async like (serving up multiple requests on startup). When the token is expired, I try to refresh the token by using the refresh_token. From the log I can see that this happens three times and has the following flow:

1) remove old token and create new token
2) remove old token, which is already gone, concurrency exception
3) remove old token, which is already gone, concurrency exception

From this point it seems new calls are all invalid... probably because no good token is returned.

I've fixed this issue by catching the concurrency exception and removing the token from the context. The new flow:

1) remove old token and create new token
2) remove old token, which is already gone, concurrency exception is caught, remove token from context, create new token
3) remove old token, which is already gone, concurrency exception is caught, remove token from context, create new token

It does create 3 tokens now, where I eventually will use the last one. I don't think this is bad, but you might think differently. From what I understand, the token I'll use just works (it does), and the other two ones are just in the database. Eventually, by using the token cleanup class, those token will be removed from the database. Seems to be ok?

On a side track... I see that the refresh token expiration is sliding - extending lifetime. I would expect that this option would update the token, not delete and create. I would expect that behavior with one-time only. It is nothing wrong or so, just wanted to let you know.

If we were to change this and use an update statement, we could handle concurrency I bit differently: by adding a rowversion column, EF will try and update, see the rowversion mismatch and throw the concurrency exception. We would then reload the token from the database and return the same token instead of creating a new one. Just something to think about.

<!---
@huboard:{"order":3.71875,"milestone_order":45,"custom_state":""}
-->
