### PR TITLE
Failing integration test: Add and delete client RedirectUri values

### DIFF
--- a/Source/Core.EntityFramework.IntegrationTests/App.config
+++ b/Source/Core.EntityFramework.IntegrationTests/App.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <connectionStrings>
+    <add name="Config" connectionString="server=(LocalDb)\v11.0;database=IdentityServer3.Core.EntityFramework.IntegrationTests.Config;trusted_connection=yes;" providerName="System.Data.SqlClient" />
+    <add name="Identity" connectionString="server=(LocalDb)\v11.0;database=IdentityServer3.Core.EntityFramework.IntegrationTests.Identity;trusted_connection=yes;" providerName="System.Data.SqlClient" />
+  </connectionStrings>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/Source/Core.EntityFramework.IntegrationTests/ClientConfigurationDbContextTests.cs
+++ b/Source/Core.EntityFramework.IntegrationTests/ClientConfigurationDbContextTests.cs
@@ -1,0 +1,64 @@
+﻿using IdentityServer3.EntityFramework;
+using IdentityServer3.EntityFramework.Entities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Data.Entity;
+using System.Linq;
+
+namespace Core.EntityFramework.IntegrationTests
+{
+    [TestClass]
+    public class ClientConfigurationDbContextTests
+    {
+        private const string ConfigConnectionStringName = "Config";
+
+        public ClientConfigurationDbContextTests()
+        {
+            Database.SetInitializer<ClientConfigurationDbContext>(
+                new DropCreateDatabaseAlways<ClientConfigurationDbContext>());
+        }
+
+        [TestMethod]
+        public void CanAddAndDeleteClientRedirectUri()
+        {
+            using (var db = new ClientConfigurationDbContext(ConfigConnectionStringName))
+            {
+                db.Clients.Add(new Client
+                {
+                    ClientId = "test-client",
+                    ClientName = "Test Client"
+                });
+
+                db.SaveChanges();
+            }
+
+            using (var db = new ClientConfigurationDbContext(ConfigConnectionStringName))
+            {
+                var client = db.Clients.First();
+
+                client.RedirectUris.Add(new ClientRedirectUri
+                {
+                    Uri = "https://redirect-uri-1"
+                });
+
+                db.SaveChanges();
+            }
+
+            using (var db = new ClientConfigurationDbContext(ConfigConnectionStringName))
+            {
+                var client = db.Clients.First();
+                var redirectUri = client.RedirectUris.First();
+
+                client.RedirectUris.Remove(redirectUri);
+
+                db.SaveChanges();
+            }
+
+            using (var db = new ClientConfigurationDbContext(ConfigConnectionStringName))
+            {
+                var client = db.Clients.First();
+
+                Assert.Equals(0, client.RedirectUris.Count());
+            }
+        }
+    }
+}

--- a/Source/Core.EntityFramework.IntegrationTests/Core.EntityFramework.IntegrationTests.csproj
+++ b/Source/Core.EntityFramework.IntegrationTests/Core.EntityFramework.IntegrationTests.csproj
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0B7D20A0-BD8D-4F27-8CED-DB0620B39927}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Core.EntityFramework.IntegrationTests</RootNamespace>
+    <AssemblyName>Core.EntityFramework.IntegrationTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.2\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.2\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="IdentityServer3, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityServer3.2.0.0-build00019\lib\net45\IdentityServer3.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="ClientConfigurationDbContextTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core.EntityFramework\Core.EntityFramework.csproj">
+      <Project>{d4c0430d-3b41-422a-b1a6-ba6c68400ff1}</Project>
+      <Name>Core.EntityFramework</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/Core.EntityFramework.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/Source/Core.EntityFramework.IntegrationTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Core.EntityFramework.IntegrationTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Core.EntityFramework.IntegrationTests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6a746eaa-59bf-48dd-8c00-2f231a0e16b6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Core.EntityFramework.IntegrationTests/packages.config
+++ b/Source/Core.EntityFramework.IntegrationTests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
+  <package id="IdentityServer3" version="2.0.0-build00019" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
+</packages>

--- a/Source/IdentityServer3.EntityFramework.sln
+++ b/Source/IdentityServer3.EntityFramework.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.EntityFramework.Tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Host", "SelfHost\Host.csproj", "{F0B58CB4-548B-4934-84D3-8003160FF046}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.EntityFramework.IntegrationTests", "Core.EntityFramework.IntegrationTests\Core.EntityFramework.IntegrationTests.csproj", "{0B7D20A0-BD8D-4F27-8CED-DB0620B39927}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{F0B58CB4-548B-4934-84D3-8003160FF046}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0B58CB4-548B-4934-84D3-8003160FF046}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0B58CB4-548B-4934-84D3-8003160FF046}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B7D20A0-BD8D-4F27-8CED-DB0620B39927}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B7D20A0-BD8D-4F27-8CED-DB0620B39927}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B7D20A0-BD8D-4F27-8CED-DB0620B39927}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B7D20A0-BD8D-4F27-8CED-DB0620B39927}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Not sure if this is a bug or I'm doing it wrong, but I've created an integration test for a scenario I believe should work with creating and deleting client **RedirectUris** values. This should be a failing test.

If you want to merge this in later for any reason I can rebase, I'm aware this isn't mergeable in its current form.