### PR TITLE
Failing integration test: Add and delete client RedirectUri values

### DIFF
--- a/Source/Core.EntityFramework.IntegrationTests/App.config
+++ b/Source/Core.EntityFramework.IntegrationTests/App.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <connectionStrings>
+    <add name="Config" connectionString="server=(LocalDb)\v11.0;database=IdentityServer3.Core.EntityFramework.IntegrationTests.Config;trusted_connection=yes;" providerName="System.Data.SqlClient" />
+    <add name="Identity" connectionString="server=(LocalDb)\v11.0;database=IdentityServer3.Core.EntityFramework.IntegrationTests.Identity;trusted_connection=yes;" providerName="System.Data.SqlClient" />
+  </connectionStrings>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/Source/Core.EntityFramework.IntegrationTests/ClientConfigurationDbContextTests.cs
+++ b/Source/Core.EntityFramework.IntegrationTests/ClientConfigurationDbContextTests.cs
@@ -1,0 +1,63 @@
+﻿using IdentityServer3.EntityFramework;
+using IdentityServer3.EntityFramework.Entities;
+using System.Data.Entity;
+using System.Linq;
+using Xunit;
+
+namespace Core.EntityFramework.IntegrationTests
+{
+    public class ClientConfigurationDbContextTests
+    {
+        private const string ConfigConnectionStringName = "Config";
+
+        public ClientConfigurationDbContextTests()
+        {
+            Database.SetInitializer<ClientConfigurationDbContext>(
+                new DropCreateDatabaseAlways<ClientConfigurationDbContext>());
+        }
+
+        [Fact]
+        public void CanAddAndDeleteClientRedirectUri()
+        {
+            using (var db = new ClientConfigurationDbContext(ConfigConnectionStringName))
+            {
+                db.Clients.Add(new Client
+                {
+                    ClientId = "test-client",
+                    ClientName = "Test Client"
+                });
+
+                db.SaveChanges();
+            }
+
+            using (var db = new ClientConfigurationDbContext(ConfigConnectionStringName))
+            {
+                var client = db.Clients.First();
+
+                client.RedirectUris.Add(new ClientRedirectUri
+                {
+                    Uri = "https://redirect-uri-1"
+                });
+
+                db.SaveChanges();
+            }
+
+            using (var db = new ClientConfigurationDbContext(ConfigConnectionStringName))
+            {
+                var client = db.Clients.First();
+                var redirectUri = client.RedirectUris.First();
+
+                client.RedirectUris.Remove(redirectUri);
+
+                db.SaveChanges();
+            }
+
+            using (var db = new ClientConfigurationDbContext(ConfigConnectionStringName))
+            {
+                var client = db.Clients.First();
+
+                Assert.Equal(0, client.RedirectUris.Count());
+            }
+        }
+    }
+}

--- a/Source/Core.EntityFramework.IntegrationTests/Core.EntityFramework.IntegrationTests.csproj
+++ b/Source/Core.EntityFramework.IntegrationTests/Core.EntityFramework.IntegrationTests.csproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{10DFC7DC-3CF0-4687-8806-DC678069A866}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Core.EntityFramework.IntegrationTests</RootNamespace>
+    <AssemblyName>Core.EntityFramework.IntegrationTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>44459eb3</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ClientConfigurationDbContextTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core.EntityFramework\Core.EntityFramework.csproj">
+      <Project>{d4c0430d-3b41-422a-b1a6-ba6c68400ff1}</Project>
+      <Name>Core.EntityFramework</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/Core.EntityFramework.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/Source/Core.EntityFramework.IntegrationTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Core.EntityFramework.IntegrationTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Core.EntityFramework.IntegrationTests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b9d58899-260b-4afa-8e00-0402320eabae")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Core.EntityFramework.IntegrationTests/packages.config
+++ b/Source/Core.EntityFramework.IntegrationTests/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+</packages>

--- a/Source/Core.EntityFramework/Serialization/ClaimsPrincipalConverter.cs
+++ b/Source/Core.EntityFramework/Serialization/ClaimsPrincipalConverter.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using IdentityServer3.Core;
 using Newtonsoft.Json;
 using System;
 using System.Linq;

--- a/Source/IdentityServer3.EntityFramework.sln
+++ b/Source/IdentityServer3.EntityFramework.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Host", "SelfHost\Host.cspro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.EntityFramework.Tests", "Core.EntityFramework.Tests\Core.EntityFramework.Tests.csproj", "{060B3BCF-EBA0-4F2F-9E5B-11E2A628EC3D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.EntityFramework.IntegrationTests", "Core.EntityFramework.IntegrationTests\Core.EntityFramework.IntegrationTests.csproj", "{10DFC7DC-3CF0-4687-8806-DC678069A866}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{060B3BCF-EBA0-4F2F-9E5B-11E2A628EC3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{060B3BCF-EBA0-4F2F-9E5B-11E2A628EC3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{060B3BCF-EBA0-4F2F-9E5B-11E2A628EC3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10DFC7DC-3CF0-4687-8806-DC678069A866}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10DFC7DC-3CF0-4687-8806-DC678069A866}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10DFC7DC-3CF0-4687-8806-DC678069A866}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10DFC7DC-3CF0-4687-8806-DC678069A866}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Not sure if this is a bug or I'm doing it wrong, but I've created an integration test for a scenario I believe should work with creating and deleting client **RedirectUris** values. This should be a failing test.

I built this on #52 that adds a using statement.