### PR TITLE
Remove AutoMapper AssertConfigurationIsValid

### DIFF
--- a/Source/Core.EntityFramework/Extensions/EntitiesMap.cs
+++ b/Source/Core.EntityFramework/Extensions/EntitiesMap.cs
@@ -36,8 +36,6 @@ namespace Thinktecture.IdentityServer.EntityFramework.Entities
                 .ForMember(x => x.ScopeRestrictions, opt => opt.MapFrom(src => src.ScopeRestrictions.Select(x => x.Scope)))
                 .ForMember(x => x.AllowedCorsOrigins, opt => opt.MapFrom(src => src.AllowedCorsOrigins.Select(x => x.Origin)))
                 .ForMember(x => x.Claims, opt => opt.MapFrom(src => src.Claims.Select(x => new Claim(x.Type, x.Value))));
-
-            Mapper.AssertConfigurationIsValid();
         }
 
         public static Thinktecture.IdentityServer.Core.Models.Scope ToModel(this Entities.Scope s)

--- a/Source/Core.EntityFramework/Extensions/ModelsMap.cs
+++ b/Source/Core.EntityFramework/Extensions/ModelsMap.cs
@@ -39,8 +39,6 @@ namespace Thinktecture.IdentityServer.Core.Models
                 .ForMember(x => x.ScopeRestrictions, opt => opt.MapFrom(src => src.ScopeRestrictions.Select(x => new Entities.ClientScopeRestriction { Scope = x })))
                 .ForMember(x => x.AllowedCorsOrigins, opt => opt.MapFrom(src => src.AllowedCorsOrigins.Select(x => new Entities.ClientCorsOrigin { Origin = x })))
                 .ForMember(x => x.Claims, opt => opt.MapFrom(src => src.Claims.Select(x => new Entities.ClientClaim { Type = x.Type, Value = x.Value })));
-
-            Mapper.AssertConfigurationIsValid();
         }
 
         public static Entities.Scope ToEntity(this Models.Scope s)


### PR DESCRIPTION
Working with existing code where AutoMapper is heavily used and the maps don't contain Ignores for a bunch of existing fields, AutoMapper at runtime ignores those fields.  Ideally one would go in and update all of the maps to add the ignores, but I can't do this and I suspect other people could run in to this problem.  Can I suggest that you put the AssertConfigurationIsValid for automapper in your unit tests and remove it from the actual library?

<!---
@huboard:{"order":13.020638704299927,"milestone_order":61,"custom_state":""}
-->
