### PR TITLE
Interfaces for db contexts

### DIFF
--- a/Source/Core.EntityFramework/Core.EntityFramework.csproj
+++ b/Source/Core.EntityFramework/Core.EntityFramework.csproj
@@ -76,8 +76,12 @@
     <Compile Include="Entities\ClientCustomGrantType.cs" />
     <Compile Include="Entities\ClientSecret.cs" />
     <Compile Include="EntityFrameworkServiceOptions.cs" />
+    <Compile Include="Extensions\DbModelBuilderExtensions.cs" />
     <Compile Include="Extensions\ModelsMap.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Interfaces\IClientConfigurationDbContext.cs" />
+    <Compile Include="Interfaces\IOperationalDbContext.cs" />
+    <Compile Include="Interfaces\IScopeConfigurationDbContext.cs" />
     <Compile Include="Registrations\ClientConfigurationCorsPolicyRegistration.cs" />
     <Compile Include="Services\ClientConfigurationCorsPolicyService.cs" />
     <Compile Include="Stores\AuthorizationCodeStore.cs" />

--- a/Source/Core.EntityFramework/DbContexts/ClientConfigurationDbContext.cs
+++ b/Source/Core.EntityFramework/DbContexts/ClientConfigurationDbContext.cs
@@ -15,11 +15,10 @@
  */
 using System.Data.Entity;
 using IdentityServer3.EntityFramework.Entities;
-using System.Collections.Specialized;
 
 namespace IdentityServer3.EntityFramework
 {
-    public class ClientConfigurationDbContext : BaseDbContext
+    public class ClientConfigurationDbContext : BaseDbContext, IClientConfigurationDbContext
     {
         public ClientConfigurationDbContext()
             : this(EfConstants.ConnectionName)
@@ -38,24 +37,7 @@ namespace IdentityServer3.EntityFramework
 
         protected override void ConfigureChildCollections()
         {
-            this.Set<Client>().Local.CollectionChanged +=
-                delegate(object sender, NotifyCollectionChangedEventArgs e)
-                {
-                    if (e.Action == NotifyCollectionChangedAction.Add)
-                    {
-                        foreach (Client item in e.NewItems)
-                        {
-                            RegisterDeleteOnRemove(item.ClientSecrets);
-                            RegisterDeleteOnRemove(item.RedirectUris);
-                            RegisterDeleteOnRemove(item.PostLogoutRedirectUris);
-                            RegisterDeleteOnRemove(item.AllowedScopes);
-                            RegisterDeleteOnRemove(item.IdentityProviderRestrictions);
-                            RegisterDeleteOnRemove(item.Claims);
-                            RegisterDeleteOnRemove(item.AllowedCustomGrantTypes);
-                            RegisterDeleteOnRemove(item.AllowedCorsOrigins);
-                        }
-                    }
-                };
+            this.RegisterClientChildTablesForDelete<Client>();
         }
 
         public DbSet<Client> Clients { get; set; }
@@ -63,34 +45,7 @@ namespace IdentityServer3.EntityFramework
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<Client>()
-                .ToTable(EfConstants.TableNames.Client, Schema);
-            modelBuilder.Entity<Client>()
-                .HasMany(x => x.ClientSecrets).WithRequired(x => x.Client).WillCascadeOnDelete();
-            modelBuilder.Entity<Client>()
-                .HasMany(x => x.RedirectUris).WithRequired(x => x.Client).WillCascadeOnDelete();
-            modelBuilder.Entity<Client>()
-                .HasMany(x => x.PostLogoutRedirectUris).WithRequired(x => x.Client).WillCascadeOnDelete();
-            modelBuilder.Entity<Client>()
-                .HasMany(x => x.AllowedScopes).WithRequired(x => x.Client).WillCascadeOnDelete();
-            modelBuilder.Entity<Client>()
-                .HasMany(x => x.IdentityProviderRestrictions).WithRequired(x => x.Client).WillCascadeOnDelete();
-            modelBuilder.Entity<Client>()
-                .HasMany(x => x.Claims).WithRequired(x => x.Client).WillCascadeOnDelete();
-            modelBuilder.Entity<Client>()
-                .HasMany(x => x.AllowedCustomGrantTypes).WithRequired(x => x.Client).WillCascadeOnDelete();
-            modelBuilder.Entity<Client>()
-                .HasMany(x => x.AllowedCorsOrigins).WithRequired(x => x.Client).WillCascadeOnDelete();
-
-            modelBuilder.Entity<ClientSecret>().ToTable(EfConstants.TableNames.ClientSecret, Schema);
-            modelBuilder.Entity<ClientRedirectUri>().ToTable(EfConstants.TableNames.ClientRedirectUri, Schema);
-            modelBuilder.Entity<ClientPostLogoutRedirectUri>().ToTable(EfConstants.TableNames.ClientPostLogoutRedirectUri, Schema);
-            modelBuilder.Entity<ClientScope>().ToTable(EfConstants.TableNames.ClientScopes, Schema);
-            modelBuilder.Entity<ClientIdPRestriction>().ToTable(EfConstants.TableNames.ClientIdPRestriction, Schema);
-            modelBuilder.Entity<ClientClaim>().ToTable(EfConstants.TableNames.ClientClaim, Schema);
-            modelBuilder.Entity<ClientCustomGrantType>().ToTable(EfConstants.TableNames.ClientCustomGrantType, Schema);
-            modelBuilder.Entity<ClientCorsOrigin>().ToTable(EfConstants.TableNames.ClientCorsOrigin, Schema);
+            modelBuilder.ConfigureClients(Schema);
         }
     }
 }

--- a/Source/Core.EntityFramework/DbContexts/OperationalDbContext.cs
+++ b/Source/Core.EntityFramework/DbContexts/OperationalDbContext.cs
@@ -18,7 +18,7 @@ using IdentityServer3.EntityFramework.Entities;
 
 namespace IdentityServer3.EntityFramework
 {
-    public class OperationalDbContext : BaseDbContext
+    public class OperationalDbContext : BaseDbContext, IOperationalDbContext
     {
         public OperationalDbContext()
             : this(EfConstants.ConnectionName)
@@ -35,15 +35,20 @@ namespace IdentityServer3.EntityFramework
         {
         }
 
+        protected override void ConfigureChildCollections()
+        {
+            this.RegisterConsentChildTablesForDelete<Consent>();
+            this.RegisterTokenChildTablesForDelete<Token>();
+        }
+
         public DbSet<Consent> Consents { get; set; }
         public DbSet<Token> Tokens { get; set; }
 
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<Consent>().ToTable(EfConstants.TableNames.Consent, Schema);
-            modelBuilder.Entity<Token>().ToTable(EfConstants.TableNames.Token, Schema);
+            modelBuilder.ConfigureConsents(Schema);
+            modelBuilder.ConfigureTokens(Schema);
         }
     }
 }

--- a/Source/Core.EntityFramework/DbContexts/ScopeConfigurationDbContext.cs
+++ b/Source/Core.EntityFramework/DbContexts/ScopeConfigurationDbContext.cs
@@ -15,11 +15,10 @@
  */
 using System.Data.Entity;
 using IdentityServer3.EntityFramework.Entities;
-using System.Collections.Specialized;
 
 namespace IdentityServer3.EntityFramework
 {
-    public class ScopeConfigurationDbContext : BaseDbContext
+    public class ScopeConfigurationDbContext : BaseDbContext, IScopeConfigurationDbContext
     {
         public ScopeConfigurationDbContext()
             : this(EfConstants.ConnectionName)
@@ -38,17 +37,7 @@ namespace IdentityServer3.EntityFramework
 
         protected override void ConfigureChildCollections()
         {
-            this.Set<Scope>().Local.CollectionChanged +=
-                delegate(object sender, NotifyCollectionChangedEventArgs e)
-                {
-                    if (e.Action == NotifyCollectionChangedAction.Add)
-                    {
-                        foreach (Scope item in e.NewItems)
-                        {
-                            RegisterDeleteOnRemove(item.ScopeClaims);
-                        }
-                    }
-                };
+            this.RegisterScopeChildTablesForDelete<Scope>();
         }
 
         public DbSet<Scope> Scopes { get; set; }
@@ -56,12 +45,7 @@ namespace IdentityServer3.EntityFramework
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<Scope>()
-                .ToTable(EfConstants.TableNames.Scope, Schema)
-                .HasMany(x => x.ScopeClaims).WithRequired(x => x.Scope).WillCascadeOnDelete();
-
-            modelBuilder.Entity<ScopeClaim>().ToTable(EfConstants.TableNames.ScopeClaim, Schema);
+            modelBuilder.ConfigureScopes(Schema);
         }
     }
 }

--- a/Source/Core.EntityFramework/Extensions/DbModelBuilderExtensions.cs
+++ b/Source/Core.EntityFramework/Extensions/DbModelBuilderExtensions.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Data.Entity;
+using System.Data.Entity.Core.Objects.DataClasses;
+using IdentityServer3.EntityFramework.Entities;
+
+namespace IdentityServer3.EntityFramework
+{
+    public static class DbModelBuilderExtensions
+    {
+        public static void RegisterClientChildTablesForDelete<TClient>(this DbContext ctx) 
+            where TClient : Client 
+        {
+            ctx.Set<TClient>().Local.CollectionChanged +=
+                delegate (object sender, NotifyCollectionChangedEventArgs e)
+                {
+                    if (e.Action == NotifyCollectionChangedAction.Add)
+                    {
+                        foreach (Client item in e.NewItems)
+                        {
+                            RegisterDeleteOnRemove(item.ClientSecrets, ctx);
+                            RegisterDeleteOnRemove(item.RedirectUris, ctx);
+                            RegisterDeleteOnRemove(item.PostLogoutRedirectUris, ctx);
+                            RegisterDeleteOnRemove(item.AllowedScopes, ctx);
+                            RegisterDeleteOnRemove(item.IdentityProviderRestrictions, ctx);
+                            RegisterDeleteOnRemove(item.Claims, ctx);
+                            RegisterDeleteOnRemove(item.AllowedCustomGrantTypes, ctx);
+                            RegisterDeleteOnRemove(item.AllowedCorsOrigins, ctx);
+                        }
+                    }
+                };
+        }
+
+        public static void RegisterScopeChildTablesForDelete<TScope>(this DbContext ctx)
+            where TScope : Scope
+        {
+            ctx.Set<TScope>().Local.CollectionChanged +=
+                delegate (object sender, NotifyCollectionChangedEventArgs e)
+                {
+                    if (e.Action == NotifyCollectionChangedAction.Add)
+                    {
+                        foreach (Scope item in e.NewItems)
+                        {
+                            RegisterDeleteOnRemove(item.ScopeClaims, ctx);
+                        }
+                    }
+                };
+        }
+
+        public static void RegisterConsentChildTablesForDelete<TConsent>(this DbContext ctx)
+            where TConsent : Consent
+        {
+            // empty
+        }
+
+        public static void RegisterTokenChildTablesForDelete<TToken>(this DbContext ctx)
+            where TToken : Token
+        {
+            // empty
+        }
+
+        internal static void RegisterDeleteOnRemove<TChild>(this ICollection<TChild> collection, DbContext ctx)
+            where TChild : class
+        {
+            var entities = collection as EntityCollection<TChild>;
+            if (entities != null)
+            {
+                entities.AssociationChanged += delegate (object sender, CollectionChangeEventArgs e)
+                {
+                    if (e.Action == CollectionChangeAction.Remove)
+                    {
+                        var entity = e.Element as TChild;
+                        if (entity != null)
+                        {
+                            ctx.Entry(entity).State = EntityState.Deleted;
+                        }
+                    }
+                };
+            }
+        }
+
+        public static void ConfigureClients(this DbModelBuilder modelBuilder, string schema)
+        {
+            modelBuilder.Entity<Client>()
+                .ToTable(EfConstants.TableNames.Client, schema);
+            modelBuilder.Entity<Client>()
+                .HasMany(x => x.ClientSecrets).WithRequired(x => x.Client).WillCascadeOnDelete();
+            modelBuilder.Entity<Client>()
+                .HasMany(x => x.RedirectUris).WithRequired(x => x.Client).WillCascadeOnDelete();
+            modelBuilder.Entity<Client>()
+                .HasMany(x => x.PostLogoutRedirectUris).WithRequired(x => x.Client).WillCascadeOnDelete();
+            modelBuilder.Entity<Client>()
+                .HasMany(x => x.AllowedScopes).WithRequired(x => x.Client).WillCascadeOnDelete();
+            modelBuilder.Entity<Client>()
+                .HasMany(x => x.IdentityProviderRestrictions).WithRequired(x => x.Client).WillCascadeOnDelete();
+            modelBuilder.Entity<Client>()
+                .HasMany(x => x.Claims).WithRequired(x => x.Client).WillCascadeOnDelete();
+            modelBuilder.Entity<Client>()
+                .HasMany(x => x.AllowedCustomGrantTypes).WithRequired(x => x.Client).WillCascadeOnDelete();
+            modelBuilder.Entity<Client>()
+                .HasMany(x => x.AllowedCorsOrigins).WithRequired(x => x.Client).WillCascadeOnDelete();
+
+            modelBuilder.Entity<ClientSecret>().ToTable(EfConstants.TableNames.ClientSecret, schema);
+            modelBuilder.Entity<ClientRedirectUri>().ToTable(EfConstants.TableNames.ClientRedirectUri, schema);
+            modelBuilder.Entity<ClientPostLogoutRedirectUri>().ToTable(EfConstants.TableNames.ClientPostLogoutRedirectUri, schema);
+            modelBuilder.Entity<ClientScope>().ToTable(EfConstants.TableNames.ClientScopes, schema);
+            modelBuilder.Entity<ClientIdPRestriction>().ToTable(EfConstants.TableNames.ClientIdPRestriction, schema);
+            modelBuilder.Entity<ClientClaim>().ToTable(EfConstants.TableNames.ClientClaim, schema);
+            modelBuilder.Entity<ClientCustomGrantType>().ToTable(EfConstants.TableNames.ClientCustomGrantType, schema);
+            modelBuilder.Entity<ClientCorsOrigin>().ToTable(EfConstants.TableNames.ClientCorsOrigin, schema);
+        }
+
+        public static void ConfigureConsents(this DbModelBuilder modelBuilder, string schema)
+        {
+            modelBuilder.Entity<Consent>().ToTable(EfConstants.TableNames.Consent, schema);
+        }
+
+        public static void ConfigureTokens(this DbModelBuilder modelBuilder, string schema)
+        {
+            modelBuilder.Entity<Token>().ToTable(EfConstants.TableNames.Token, schema);
+        }
+        public static void ConfigureScopes(this DbModelBuilder modelBuilder, string schema)
+        {
+            modelBuilder.Entity<Scope>()
+                .ToTable(EfConstants.TableNames.Scope, schema)
+                .HasMany(x => x.ScopeClaims).WithRequired(x => x.Scope).WillCascadeOnDelete();
+
+            modelBuilder.Entity<ScopeClaim>().ToTable(EfConstants.TableNames.ScopeClaim, schema);
+        }
+    }
+}

--- a/Source/Core.EntityFramework/Extensions/IdentityServerServiceFactoryExtensions.cs
+++ b/Source/Core.EntityFramework/Extensions/IdentityServerServiceFactoryExtensions.cs
@@ -26,7 +26,7 @@ namespace IdentityServer3.Core.Configuration
             if (factory == null) throw new ArgumentNullException("factory");
             if (options == null) throw new ArgumentNullException("options");
 
-            factory.Register(new Registration<OperationalDbContext>(resolver => new OperationalDbContext(options.ConnectionString, options.Schema)));
+            factory.Register(new Registration<IOperationalDbContext>(resolver => new OperationalDbContext(options.ConnectionString, options.Schema)));
             factory.AuthorizationCodeStore = new Registration<IAuthorizationCodeStore, AuthorizationCodeStore>();
             factory.TokenHandleStore = new Registration<ITokenHandleStore, TokenHandleStore>();
             factory.ConsentStore = new Registration<IConsentStore, ConsentStore>();
@@ -44,7 +44,7 @@ namespace IdentityServer3.Core.Configuration
             if (factory == null) throw new ArgumentNullException("factory");
             if (options == null) throw new ArgumentNullException("options");
 
-            factory.Register(new Registration<ClientConfigurationDbContext>(resolver => new ClientConfigurationDbContext(options.ConnectionString, options.Schema)));
+            factory.Register(new Registration<IClientConfigurationDbContext>(resolver => new ClientConfigurationDbContext(options.ConnectionString, options.Schema)));
             factory.ClientStore = new Registration<IClientStore, ClientStore>();
             factory.CorsPolicyService = new ClientConfigurationCorsPolicyRegistration(options);
         }
@@ -54,7 +54,7 @@ namespace IdentityServer3.Core.Configuration
             if (factory == null) throw new ArgumentNullException("factory");
             if (options == null) throw new ArgumentNullException("options");
 
-            factory.Register(new Registration<ScopeConfigurationDbContext>(resolver => new ScopeConfigurationDbContext(options.ConnectionString, options.Schema)));
+            factory.Register(new Registration<IScopeConfigurationDbContext>(resolver => new ScopeConfigurationDbContext(options.ConnectionString, options.Schema)));
             factory.ScopeStore = new Registration<IScopeStore, ScopeStore>();
         }
     }

--- a/Source/Core.EntityFramework/Interfaces/IClientConfigurationDbContext.cs
+++ b/Source/Core.EntityFramework/Interfaces/IClientConfigurationDbContext.cs
@@ -1,0 +1,10 @@
+﻿using System.Data.Entity;
+using IdentityServer3.EntityFramework.Entities;
+
+namespace IdentityServer3.EntityFramework
+{
+    public interface IClientConfigurationDbContext
+    {
+        DbSet<Client> Clients { get; set; }
+    }
+}

--- a/Source/Core.EntityFramework/Interfaces/IOperationalDbContext.cs
+++ b/Source/Core.EntityFramework/Interfaces/IOperationalDbContext.cs
@@ -1,11 +1,15 @@
-﻿using System.Data.Entity;
+﻿using System;
+using System.Data.Entity;
+using System.Threading.Tasks;
 using IdentityServer3.EntityFramework.Entities;
 
 namespace IdentityServer3.EntityFramework
 {
-    public interface IOperationalDbContext
+    public interface IOperationalDbContext : IDisposable
     {
         DbSet<Consent> Consents { get; set; }
         DbSet<Token> Tokens { get; set; }
+
+        Task<int> SaveChangesAsync();
     }
 }

--- a/Source/Core.EntityFramework/Interfaces/IOperationalDbContext.cs
+++ b/Source/Core.EntityFramework/Interfaces/IOperationalDbContext.cs
@@ -1,0 +1,11 @@
+﻿using System.Data.Entity;
+using IdentityServer3.EntityFramework.Entities;
+
+namespace IdentityServer3.EntityFramework
+{
+    public interface IOperationalDbContext
+    {
+        DbSet<Consent> Consents { get; set; }
+        DbSet<Token> Tokens { get; set; }
+    }
+}

--- a/Source/Core.EntityFramework/Interfaces/IScopeConfigurationDbContext.cs
+++ b/Source/Core.EntityFramework/Interfaces/IScopeConfigurationDbContext.cs
@@ -1,0 +1,10 @@
+﻿using System.Data.Entity;
+using IdentityServer3.EntityFramework.Entities;
+
+namespace IdentityServer3.EntityFramework
+{
+    public interface IScopeConfigurationDbContext
+    {
+        DbSet<Scope> Scopes { get; set; }
+    }
+}

--- a/Source/Core.EntityFramework/Registrations/ClientConfigurationCorsPolicyRegistration.cs
+++ b/Source/Core.EntityFramework/Registrations/ClientConfigurationCorsPolicyRegistration.cs
@@ -34,7 +34,7 @@ namespace IdentityServer3.EntityFramework
         {
             if (options == null) throw new ArgumentNullException("options");
 
-            this.AdditionalRegistrations.Add(new Registration<ClientConfigurationDbContext>(resolver => new ClientConfigurationDbContext(options.ConnectionString, options.Schema)));
+            this.AdditionalRegistrations.Add(new Registration<IClientConfigurationDbContext>(resolver => new ClientConfigurationDbContext(options.ConnectionString, options.Schema)));
         }
     }
 }

--- a/Source/Core.EntityFramework/Services/ClientConfigurationCorsPolicyService.cs
+++ b/Source/Core.EntityFramework/Services/ClientConfigurationCorsPolicyService.cs
@@ -25,9 +25,9 @@ namespace IdentityServer3.EntityFramework
 {
     public class ClientConfigurationCorsPolicyService : ICorsPolicyService
     {
-        ClientConfigurationDbContext context;
+        private readonly IClientConfigurationDbContext context;
 
-        public ClientConfigurationCorsPolicyService(ClientConfigurationDbContext ctx)
+        public ClientConfigurationCorsPolicyService(IClientConfigurationDbContext ctx)
         {
             this.context = ctx;
         }

--- a/Source/Core.EntityFramework/Stores/AuthorizationCodeStore.cs
+++ b/Source/Core.EntityFramework/Stores/AuthorizationCodeStore.cs
@@ -23,7 +23,7 @@ namespace IdentityServer3.EntityFramework
 {
     public class AuthorizationCodeStore : BaseTokenStore<AuthorizationCode>, IAuthorizationCodeStore
     {
-        public AuthorizationCodeStore(OperationalDbContext context, IScopeStore scopeStore, IClientStore clientStore)
+        public AuthorizationCodeStore(IOperationalDbContext context, IScopeStore scopeStore, IClientStore clientStore)
             : base(context, TokenType.AuthorizationCode, scopeStore, clientStore)
         {
         }

--- a/Source/Core.EntityFramework/Stores/BaseTokenStore.cs
+++ b/Source/Core.EntityFramework/Stores/BaseTokenStore.cs
@@ -29,12 +29,12 @@ namespace IdentityServer3.EntityFramework
 {
     public abstract class BaseTokenStore<T> where T : class
     {
-        protected readonly OperationalDbContext context;
+        protected readonly IOperationalDbContext context;
         protected readonly TokenType tokenType;
         protected readonly IScopeStore scopeStore;
         protected readonly IClientStore clientStore;
 
-        protected BaseTokenStore(OperationalDbContext context, TokenType tokenType, IScopeStore scopeStore, IClientStore clientStore)
+        protected BaseTokenStore(IOperationalDbContext context, TokenType tokenType, IScopeStore scopeStore, IClientStore clientStore)
         {
             if (context == null) throw new ArgumentNullException("context");
             if (scopeStore == null) throw new ArgumentNullException("scopeStore");

--- a/Source/Core.EntityFramework/Stores/ClientStore.cs
+++ b/Source/Core.EntityFramework/Stores/ClientStore.cs
@@ -25,9 +25,9 @@ namespace IdentityServer3.EntityFramework
 {
     public class ClientStore : IClientStore
     {
-        private readonly ClientConfigurationDbContext context;
+        private readonly IClientConfigurationDbContext context;
 
-        public ClientStore(ClientConfigurationDbContext context)
+        public ClientStore(IClientConfigurationDbContext context)
         {
             if (context == null) throw new ArgumentNullException("context");
             

--- a/Source/Core.EntityFramework/Stores/ConsentStore.cs
+++ b/Source/Core.EntityFramework/Stores/ConsentStore.cs
@@ -25,9 +25,9 @@ namespace IdentityServer3.EntityFramework
 {
     public class ConsentStore : IConsentStore
     {
-        private readonly OperationalDbContext context;
+        private readonly IOperationalDbContext context;
 
-        public ConsentStore(OperationalDbContext context)
+        public ConsentStore(IOperationalDbContext context)
         {
             if (context == null) throw new ArgumentNullException("context");
             

--- a/Source/Core.EntityFramework/Stores/RefreshTokenStore.cs
+++ b/Source/Core.EntityFramework/Stores/RefreshTokenStore.cs
@@ -24,7 +24,7 @@ namespace IdentityServer3.EntityFramework
 {
     public class RefreshTokenStore : BaseTokenStore<RefreshToken>, IRefreshTokenStore
     {
-        public RefreshTokenStore(OperationalDbContext context, IScopeStore scopeStore, IClientStore clientStore)
+        public RefreshTokenStore(IOperationalDbContext context, IScopeStore scopeStore, IClientStore clientStore)
             : base(context, TokenType.RefreshToken, scopeStore, clientStore)
         {
         }

--- a/Source/Core.EntityFramework/Stores/ScopeStore.cs
+++ b/Source/Core.EntityFramework/Stores/ScopeStore.cs
@@ -26,9 +26,9 @@ namespace IdentityServer3.EntityFramework
 {
     public class ScopeStore : IScopeStore
     {
-        private readonly ScopeConfigurationDbContext context;
+        private readonly IScopeConfigurationDbContext context;
 
-        public ScopeStore(ScopeConfigurationDbContext context)
+        public ScopeStore(IScopeConfigurationDbContext context)
         {
             if (context == null) throw new ArgumentNullException("context");
 

--- a/Source/Core.EntityFramework/Stores/TokenHandleStore.cs
+++ b/Source/Core.EntityFramework/Stores/TokenHandleStore.cs
@@ -22,7 +22,7 @@ namespace IdentityServer3.EntityFramework
 {
     public class TokenHandleStore : BaseTokenStore<Token>, ITokenHandleStore
     {
-        public TokenHandleStore(OperationalDbContext context, IScopeStore scopeStore, IClientStore clientStore)
+        public TokenHandleStore(IOperationalDbContext context, IScopeStore scopeStore, IClientStore clientStore)
             : base(context, Entities.TokenType.TokenHandle, scopeStore, clientStore)
         {
         }

--- a/Source/Core.EntityFramework/TokenCleanup.cs
+++ b/Source/Core.EntityFramework/TokenCleanup.cs
@@ -87,13 +87,18 @@ namespace IdentityServer3.EntityFramework
             }
         }
 
+        public virtual IOperationalDbContext CreateOperationalDbContext()
+        {
+            return new OperationalDbContext(options.ConnectionString, options.Schema);
+        }
+
         private async Task ClearTokens()
         {
             try
             {
                 Logger.Info("Clearing tokens");
 
-                using (var db = new OperationalDbContext(this.options.ConnectionString, this.options.Schema))
+                using (var db = CreateOperationalDbContext())
                 {
                     var query =
                         from token in db.Tokens


### PR DESCRIPTION
This adds interfaces for db contexts (*IClientConfigurationDbContext*, *IOperationalDbContext* and *IScopeConfigurationDbContext*) to have an option use a single db context instead of 3.

```csharp
public class SingleDbContext : BaseDbContext, 
    IClientConfigurationDbContext, 
    IOperationalDbContext, 
    IScopeConfigurationDbContext
```
Also EF configuration moved from db contexts to *DbModelBuilderExtensions*.

