### PR TITLE
Improve perf of token cleanup

### DIFF
--- a/Source/Core.EntityFramework.IntegrationTests/ClientConfigurationDbContextTests.cs
+++ b/Source/Core.EntityFramework.IntegrationTests/ClientConfigurationDbContextTests.cs
@@ -2,6 +2,7 @@
 using IdentityServer3.EntityFramework.Entities;
 using System.Data.Entity;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Core.EntityFramework.IntegrationTests
@@ -14,6 +15,22 @@ namespace Core.EntityFramework.IntegrationTests
         {
             Database.SetInitializer<ClientConfigurationDbContext>(
                 new DropCreateDatabaseAlways<ClientConfigurationDbContext>());
+
+            //Database.SetInitializer<OperationalDbContext>(
+            //    new DropCreateDatabaseAlways<OperationalDbContext>());
+        }
+
+        [Fact]
+        public void CleansUpDatabase()
+        {
+            var cleanUp = new TokenCleanup(new EntityFrameworkServiceOptions
+            {
+                ConnectionString = ConfigConnectionStringName
+            },3);
+
+            cleanUp.Start();
+
+            Task.Delay(100000).Wait();
         }
 
         [Fact]

--- a/Source/Core.EntityFramework/Core.EntityFramework.csproj
+++ b/Source/Core.EntityFramework/Core.EntityFramework.csproj
@@ -44,6 +44,10 @@
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="EntityFramework.Extended, Version=6.0.0.0, Culture=neutral, PublicKeyToken=05b7e29bdd433584, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.Extended.6.1.0.168\lib\net45\EntityFramework.Extended.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>

--- a/Source/Core.EntityFramework/Extensions/DbModelBuilderExtensions.cs
+++ b/Source/Core.EntityFramework/Extensions/DbModelBuilderExtensions.cs
@@ -17,8 +17,10 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity;
 using System.Data.Entity.Core.Objects.DataClasses;
+using System.Data.Entity.Infrastructure.Annotations;
 using IdentityServer3.EntityFramework.Entities;
 
 namespace IdentityServer3.EntityFramework
@@ -136,6 +138,8 @@ namespace IdentityServer3.EntityFramework
         public static void ConfigureTokens(this DbModelBuilder modelBuilder, string schema)
         {
             modelBuilder.Entity<Token>().ToTable(EfConstants.TableNames.Token, schema);
+            modelBuilder.Entity<Token>().Property(x => x.Expiry)
+                .HasColumnAnnotation("Index", new IndexAnnotation(new IndexAttribute("Expiry") { IsUnique = false}));
         }
         public static void ConfigureScopes(this DbModelBuilder modelBuilder, string schema)
         {

--- a/Source/Core.EntityFramework/TokenCleanup.cs
+++ b/Source/Core.EntityFramework/TokenCleanup.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using EntityFramework.Extensions;
 using IdentityServer3.EntityFramework.Logging;
 
 namespace IdentityServer3.EntityFramework
@@ -100,14 +101,9 @@ namespace IdentityServer3.EntityFramework
 
                 using (var db = CreateOperationalDbContext())
                 {
-                    var query =
-                        from token in db.Tokens
-                        where token.Expiry < DateTimeOffset.UtcNow
-                        select token;
-
-                    db.Tokens.RemoveRange(query);
-
-                    await db.SaveChangesAsync();
+                    await db.Tokens
+                        .Where(x => x.Expiry < DateTimeOffset.UtcNow)
+                        .DeleteAsync();
                 }
             }
             catch(Exception ex)

--- a/Source/Core.EntityFramework/packages.config
+++ b/Source/Core.EntityFramework/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="EntityFramework.Extended" version="6.1.0.168" targetFramework="net45" />
   <package id="IdentityServer3" version="2.5.0-build00468" targetFramework="net45" />
   <package id="LibLog" version="4.2.4" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />


### PR DESCRIPTION
resolves #89 

Use entity framework extended to run the token clean up process.  This
pevent the cleanup code pulling the data back before deleting it.

Add an index to the expiry field to improve performance of selection.

This current solution does not include @tbarcelon proposed plan to move the clustered index to expiry.  It just adds an extra non clustered index.

Note: I've included a test that I would remove before merging this code it just so you can run it quickly run it to check it works. 

I've profiled the sql that gets executed by entityframework extended.  

```
DELETE [dbo].[Tokens]
FROM [dbo].[Tokens] AS j0 INNER JOIN (
SELECT 
    1 AS [C1], 
    [Extent1].[Key] AS [Key], 
    [Extent1].[TokenType] AS [TokenType]
    FROM [dbo].[Tokens] AS [Extent1]
    WHERE [Extent1].[Expiry] < '2016-05-13 14:19:03.6501655 +00:00'
) AS j1 ON (j0.[Key] = j1.[Key] AND j0.[TokenType] = j1.[TokenType])
```
Included execution plan
![image](https://cloud.githubusercontent.com/assets/507875/15251084/a7b6da56-191f-11e6-88d2-6bf004f9e768.png)

Less than ideal compared to the alternative but probably good enough. 

```
DELETE FROM [dbo].[Tokens] WHERE [Expiry] < '2016-05-13 14:19:03.6501655 +00:00'
```

![image](https://cloud.githubusercontent.com/assets/507875/15251157/f55efa72-191f-11e6-95a0-2aae4d974666.png)
