### PR TITLE
Improved performance of ConsentStore.StringifyScopes

### DIFF
--- a/Source/Core.EntityFramework.Tests/Core.EntityFramework.Tests.csproj
+++ b/Source/Core.EntityFramework.Tests/Core.EntityFramework.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Serialization\ClaimsPrincipalConverterTests.cs" />
     <Compile Include="Serialization\ClientConverterTests.cs" />
     <Compile Include="Serialization\ScopeConverterTests.cs" />
+    <Compile Include="Extensions\StringExtensionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Source/Core.EntityFramework.Tests/Extensions/StringExtensionTests.cs
+++ b/Source/Core.EntityFramework.Tests/Extensions/StringExtensionTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IdentityServer3.EntityFramework.Tests.Extensions
+{ 
+    public class StringExtensionTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public StringExtensionTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void CanStringifyAListOfScopes()
+        {
+            var scopes = new List<string>
+            {
+                "Scope 1",
+                "Scope 2",
+                "Scope 3"
+            };
+
+            var stringified = scopes.GetAsCommaSeparatedString();
+
+            Assert.Equal("Scope 1,Scope 2,Scope 3", stringified);
+        }
+
+        [Fact]
+        public void IsFasterThanOldImplementation()
+        {
+            const int iterations = 10*1000;
+
+            var scopes = new List<string>();
+            for (var i = 0; i < 50; i++)
+            {
+                scopes.Add(string.Format("Scope {0}", i));
+            }
+
+            var stopwatch = new Stopwatch();
+
+            stopwatch.Start();
+            for (var i = 0; i < iterations; i++)
+            {
+                scopes.GetAsCommaSeparatedString();
+            }
+            stopwatch.Stop();
+
+            var newImplTimeSpan = stopwatch.Elapsed;
+
+            stopwatch.Reset();
+            stopwatch.Start();
+            for (var i = 0; i < iterations; i++)
+            {
+                OldStringifyScopes(scopes);
+            }
+            stopwatch.Stop();
+
+            var oldImplTimeSpan = stopwatch.Elapsed;
+
+            _output.WriteLine("Old implementation took: {0}ms; New implemenation took: {1}ms", oldImplTimeSpan, newImplTimeSpan);
+            Assert.True(newImplTimeSpan < oldImplTimeSpan);
+        }
+
+        private string OldStringifyScopes(IEnumerable<string> scopes)
+        {
+            if (scopes == null || !scopes.Any())
+            {
+                return null;
+            }
+
+            return scopes.Aggregate((s1, s2) => s1 + "," + s2);
+        }
+    }
+}

--- a/Source/Core.EntityFramework/Extensions/StringExtensions.cs
+++ b/Source/Core.EntityFramework/Extensions/StringExtensions.cs
@@ -15,6 +15,10 @@
  */
 
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
 namespace IdentityServer3.EntityFramework
 {
     internal static class StringExtensions
@@ -36,6 +40,26 @@ namespace IdentityServer3.EntityFramework
             }
 
             return null;
+        }
+
+        public static string GetAsCommaSeparatedString(this IEnumerable<string> collection)
+        {
+            if (collection == null || !collection.Any())
+            {
+                return null;
+            }
+
+            var builder = new StringBuilder();
+
+            foreach (var item in collection)
+            {
+                builder.Append(item);
+                builder.Append(",");
+            }
+
+            builder.Remove(builder.Length - 1, 1);
+
+            return builder.ToString();
         }
     }
 }

--- a/Source/Core.EntityFramework/Properties/AssemblyInfo.cs
+++ b/Source/Core.EntityFramework/Properties/AssemblyInfo.cs
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
+[assembly: InternalsVisibleTo("Core.EntityFramework.Tests")]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/Source/Core.EntityFramework/Stores/ConsentStore.cs
+++ b/Source/Core.EntityFramework/Stores/ConsentStore.cs
@@ -70,7 +70,7 @@ namespace IdentityServer3.EntityFramework
                 context.Consents.Remove(item);
             }
 
-            item.Scopes = StringifyScopes(consent.Scopes);
+            item.Scopes = consent.Scopes.GetAsCommaSeparatedString();
 
             await context.SaveChangesAsync();
         }
@@ -96,16 +96,6 @@ namespace IdentityServer3.EntityFramework
             }
 
             return scopes.Split(',');
-        }
-
-        private string StringifyScopes(IEnumerable<string> scopes)
-        {
-            if (scopes == null || !scopes.Any())
-            {
-                return null;
-            }
-
-            return scopes.Aggregate((s1, s2) => s1 + "," + s2);
         }
 
         public async Task RevokeAsync(string subject, string client)


### PR DESCRIPTION
Improved performance of ConsentStore.StringifyScopes
- Replaced current impl with extension method using StringBuilder
- Added integration tests to demonstrate performance improvement

#108