### PR TITLE
fix ConsentStore null excretion when no existing consent.

### DIFF
--- a/Source/Core.EntityFramework/Stores/ConsentStore.cs
+++ b/Source/Core.EntityFramework/Stores/ConsentStore.cs
@@ -58,7 +58,7 @@ namespace IdentityServer3.EntityFramework
 
             if (found == null)
             {
-                return null;
+                return Task.FromResult<IdentityServer3.Core.Models.Consent>(null);
             }
                 
             var result = new IdentityServer3.Core.Models.Consent


### PR DESCRIPTION
because the return type is Task<IdentityServer3.Core.Models.Consent>, so we should return Task.FromResult<IdentityServer3.Core.Models.Consent>(null) instead of null. Otherwise, null exception will be raised.