### PR TITLE
Use AsNoTracking in all EF reads

### DIFF
--- a/Source/Core.EntityFramework/Stores/BaseTokenStore.cs
+++ b/Source/Core.EntityFramework/Stores/BaseTokenStore.cs
@@ -121,21 +121,29 @@ namespace IdentityServer3.EntityFramework
 
         public async Task<IEnumerable<ITokenMetadata>> GetAllAsync(string subject)
         {
-            Entities.Token[] tokens = null;
+            string[] tokens = null;
             if (options != null && options.SynchronousReads)
             {
-                tokens = context.Tokens.Where(x =>
+                tokens = context.Tokens
+                    .AsNoTracking()
+                    .Where(x =>
                     x.SubjectId == subject &&
-                    x.TokenType == tokenType).ToArray();
+                    x.TokenType == tokenType)
+                    .Select(x => x.JsonCode)
+                    .ToArray();
             }
             else
             {
-                tokens = await context.Tokens.Where(x => 
+                tokens = await context.Tokens
+                    .AsNoTracking()
+                    .Where(x => 
                     x.SubjectId == subject &&
-                    x.TokenType == tokenType).ToArrayAsync();
+                    x.TokenType == tokenType)
+                    .Select(x => x.JsonCode)
+                    .ToArrayAsync();
             }
 
-            var results = tokens.Select(x=>ConvertFromJson(x.JsonCode)).ToArray();
+            var results = tokens.Select(x=>ConvertFromJson(x)).ToArray();
             return results.Cast<ITokenMetadata>();
         }
         

--- a/Source/Core.EntityFramework/Stores/ClientStore.cs
+++ b/Source/Core.EntityFramework/Stores/ClientStore.cs
@@ -46,6 +46,7 @@ namespace IdentityServer3.EntityFramework
         public async Task<IdentityServer3.Core.Models.Client> FindClientByIdAsync(string clientId)
         {
             var query = context.Clients
+                    .AsNoTracking()
                     .Include(x => x.ClientSecrets)
                     .Include(x => x.RedirectUris)
                     .Include(x => x.PostLogoutRedirectUris)

--- a/Source/Core.EntityFramework/Stores/ConsentStore.cs
+++ b/Source/Core.EntityFramework/Stores/ConsentStore.cs
@@ -108,11 +108,17 @@ namespace IdentityServer3.EntityFramework
             Consent[] found = null;
             if (options != null && options.SynchronousReads)
             {
-                found = context.Consents.Where(x => x.Subject == subject).ToArray();
+                found = context.Consents
+                    .AsNoTracking()
+                    .Where(x => x.Subject == subject)
+                    .ToArray();
             }
             else
             {
-                found = await context.Consents.Where(x => x.Subject == subject).ToArrayAsync();
+                found = await context.Consents
+                    .AsNoTracking()
+                    .Where(x => x.Subject == subject)
+                    .ToArrayAsync();
             }
 
             

--- a/Source/Core.EntityFramework/Stores/ScopeStore.cs
+++ b/Source/Core.EntityFramework/Stores/ScopeStore.cs
@@ -46,15 +46,15 @@ namespace IdentityServer3.EntityFramework
 
         public async Task<IEnumerable<IdentityServer3.Core.Models.Scope>> FindScopesAsync(IEnumerable<string> scopeNames)
         {
-            var scopes =
-                from s in context.Scopes.Include(x=>x.ScopeClaims).Include(x=>x.ScopeSecrets)
-                select s;
+            var scopes = context.Scopes
+                .AsNoTracking()
+                .Include(x => x.ScopeClaims)
+                .Include(x => x.ScopeSecrets);
                 
             if (scopeNames != null && scopeNames.Any())
             {
-                scopes = from s in scopes
-                            where scopeNames.Contains(s.Name)
-                            select s;
+                scopes = scopes
+                    .Where(x => scopeNames.Contains(x.Name));
             }
 
             Scope[] list = null;
@@ -72,9 +72,10 @@ namespace IdentityServer3.EntityFramework
 
         public async Task<IEnumerable<IdentityServer3.Core.Models.Scope>> GetScopesAsync(bool publicOnly = true)
         {
-            var scopes =
-                from s in context.Scopes.Include(x=>x.ScopeClaims).Include(x=>x.ScopeSecrets)
-                select s;
+            var scopes = context.Scopes
+                .AsNoTracking()
+                .Include(x => x.ScopeClaims)
+                .Include(x => x.ScopeSecrets);
                 
             if (publicOnly)
             {


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Add .AsNoTracking() method to all db read  queries
 - Slight improvement to some select statements to only bring the data needed back from the database.

#126